### PR TITLE
feat: add active connection layout with resizable panes

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,6 +74,7 @@
     "@radix-ui/react-tabs": "^1.1.12",
     "@radix-ui/themes": "^3.2.1",
     "react": "^19.1.0",
-    "react-dom": "^19.1.0"
+    "react-dom": "^19.1.0",
+    "react-resizable-panels": "^3.0.3"
   }
 }

--- a/src/renderer/App.css
+++ b/src/renderer/App.css
@@ -1,7 +1,9 @@
 .app-container {
   height: 100vh;
+  width: 100vw;
   padding: 0;
   max-width: 100%;
+  overflow: hidden;
 }
 
 .app-layout {

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -1,7 +1,8 @@
 import { useState } from 'react'
-import { Container, Flex } from '@radix-ui/themes'
+import { Container, Flex, Box } from '@radix-ui/themes'
 import { Sidebar } from './components/Layout/Sidebar'
 import { MainPanel } from './components/Layout/MainPanel'
+import { ActiveConnectionLayout } from './components/ActiveConnectionLayout'
 import './App.css'
 
 interface Connection {
@@ -29,6 +30,32 @@ function App() {
     }
   }
 
+  const handleDisconnect = async () => {
+    if (activeConnection) {
+      try {
+        // Call the disconnect API
+        await window.api.database.disconnect(activeConnection.id)
+        setActiveConnection(null)
+      } catch (error) {
+        console.error('Error disconnecting:', error)
+      }
+    }
+  }
+
+  // If there's an active connection, show only the ActiveConnectionLayout
+  if (activeConnection) {
+    return (
+      <Box className="app-container">
+        <ActiveConnectionLayout 
+          connectionId={activeConnection.id}
+          connectionName={activeConnection.name}
+          onDisconnect={handleDisconnect}
+        />
+      </Box>
+    )
+  }
+
+  // Otherwise, show the sidebar and empty state
   return (
     <Container size="4" className="app-container">
       <Flex className="app-layout">
@@ -36,7 +63,7 @@ function App() {
           onConnectionSelect={handleConnectionSelect}
           onConnectionDelete={handleConnectionDelete}
         />
-        <MainPanel activeConnection={activeConnection ? { id: activeConnection.id, name: activeConnection.name } : undefined} />
+        <MainPanel activeConnection={undefined} />
       </Flex>
     </Container>
   )

--- a/src/renderer/components/ActiveConnectionLayout/ActiveConnectionLayout.css
+++ b/src/renderer/components/ActiveConnectionLayout/ActiveConnectionLayout.css
@@ -1,0 +1,58 @@
+.active-connection-layout {
+  height: 100%;
+  width: 100%;
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+}
+
+.connection-header {
+  background: var(--gray-2);
+  border-bottom: 1px solid var(--gray-4);
+  flex-shrink: 0;
+}
+
+.panel-group {
+  flex: 1;
+  height: 100%;
+}
+
+.explorer-panel {
+  background: var(--gray-2);
+  border-right: 1px solid var(--gray-4);
+  overflow: hidden;
+}
+
+.workspace-panel {
+  background: var(--gray-1);
+  overflow: hidden;
+}
+
+.resize-handle {
+  width: 5px;
+  background: var(--gray-4);
+  cursor: col-resize;
+  position: relative;
+  transition: background-color 0.2s;
+}
+
+.resize-handle:hover {
+  background: var(--gray-6);
+}
+
+.resize-handle:active {
+  background: var(--accent-9);
+}
+
+/* Add a visual indicator on the resize handle */
+.resize-handle::after {
+  content: '';
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  width: 1px;
+  height: 20px;
+  background: var(--gray-6);
+  opacity: 0.5;
+}

--- a/src/renderer/components/ActiveConnectionLayout/ActiveConnectionLayout.tsx
+++ b/src/renderer/components/ActiveConnectionLayout/ActiveConnectionLayout.tsx
@@ -1,0 +1,43 @@
+import { Panel, PanelGroup, PanelResizeHandle } from 'react-resizable-panels'
+import { Box, Flex, Text } from '@radix-ui/themes'
+import { Button } from '../ui'
+import { DatabaseExplorer } from '../DatabaseExplorer/DatabaseExplorer'
+import { QueryWorkspace } from '../QueryWorkspace/QueryWorkspace'
+import './ActiveConnectionLayout.css'
+
+interface ActiveConnectionLayoutProps {
+  connectionId: string
+  connectionName: string
+  onDisconnect?: () => void
+}
+
+export function ActiveConnectionLayout({ connectionId, connectionName, onDisconnect }: ActiveConnectionLayoutProps) {
+  return (
+    <Box className="active-connection-layout">
+      {/* Header bar */}
+      <Flex className="connection-header" justify="between" align="center" p="2">
+        <Flex align="center" gap="2">
+          <Text size="2" weight="bold">Connected to:</Text>
+          <Text size="2">{connectionName}</Text>
+        </Flex>
+        <Button size="1" variant="soft" color="red" onClick={onDisconnect}>
+          Disconnect
+        </Button>
+      </Flex>
+      
+      <PanelGroup direction="horizontal" className="panel-group">
+        {/* Left sidebar with database explorer */}
+        <Panel defaultSize={20} minSize={15} maxSize={40} className="explorer-panel">
+          <DatabaseExplorer connectionId={connectionId} connectionName={connectionName} />
+        </Panel>
+        
+        <PanelResizeHandle className="resize-handle" />
+        
+        {/* Right side with query workspace */}
+        <Panel defaultSize={80} className="workspace-panel">
+          <QueryWorkspace connectionId={connectionId} connectionName={connectionName} />
+        </Panel>
+      </PanelGroup>
+    </Box>
+  )
+}

--- a/src/renderer/components/ActiveConnectionLayout/index.ts
+++ b/src/renderer/components/ActiveConnectionLayout/index.ts
@@ -1,0 +1,1 @@
+export { ActiveConnectionLayout } from './ActiveConnectionLayout'

--- a/src/renderer/components/DatabaseExplorer/DatabaseExplorer.css
+++ b/src/renderer/components/DatabaseExplorer/DatabaseExplorer.css
@@ -1,0 +1,28 @@
+.database-explorer {
+  height: 100%;
+  overflow: hidden;
+}
+
+.explorer-header {
+  border-bottom: 1px solid var(--gray-4);
+  background: var(--gray-2);
+}
+
+.explorer-content {
+  flex: 1;
+  height: 100%;
+}
+
+.database-item {
+  cursor: pointer;
+  border-radius: var(--radius-2);
+  transition: background-color 0.2s;
+}
+
+.database-item:hover {
+  background: var(--gray-3);
+}
+
+.database-item:active {
+  background: var(--gray-4);
+}

--- a/src/renderer/components/DatabaseExplorer/DatabaseExplorer.tsx
+++ b/src/renderer/components/DatabaseExplorer/DatabaseExplorer.tsx
@@ -1,0 +1,71 @@
+import { useState, useEffect } from 'react'
+import { Box, Flex, ScrollArea, Text } from '@radix-ui/themes'
+import { Badge } from '../ui'
+import './DatabaseExplorer.css'
+
+interface DatabaseExplorerProps {
+  connectionId: string
+  connectionName: string
+}
+
+export function DatabaseExplorer({ connectionId, connectionName }: DatabaseExplorerProps) {
+  const [databases, setDatabases] = useState<string[]>([])
+  const [loading, setLoading] = useState(true)
+
+  useEffect(() => {
+    loadDatabases()
+  }, [connectionId])
+
+  const loadDatabases = async () => {
+    try {
+      setLoading(true)
+      const result = await window.api.database.getDatabases(connectionId)
+      if (result.success && result.databases) {
+        setDatabases(result.databases)
+      }
+    } catch (error) {
+      console.error('Error loading databases:', error)
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  return (
+    <Flex direction="column" className="database-explorer">
+      <Box className="explorer-header" p="3">
+        <Text size="2" weight="bold">Database Explorer</Text>
+        <Text size="1" color="gray" style={{ display: 'block', marginTop: 4 }}>
+          {connectionName}
+        </Text>
+      </Box>
+
+      <ScrollArea className="explorer-content">
+        {loading ? (
+          <Box p="3">
+            <Text size="2" color="gray">Loading databases...</Text>
+          </Box>
+        ) : databases.length > 0 ? (
+          <Box p="2">
+            {databases.map((db) => (
+              <Flex key={db} align="center" gap="2" className="database-item" p="2">
+                <Text size="2">📁 {db}</Text>
+                <Badge size="1" color="gray">database</Badge>
+              </Flex>
+            ))}
+          </Box>
+        ) : (
+          <Box p="3">
+            <Text size="2" color="gray">No databases found</Text>
+          </Box>
+        )}
+
+        {/* Placeholder for future tree view implementation */}
+        <Box p="3" mt="4">
+          <Text size="1" color="gray" style={{ fontStyle: 'italic' }}>
+            Tables, views, and functions will be displayed here in a tree view
+          </Text>
+        </Box>
+      </ScrollArea>
+    </Flex>
+  )
+}

--- a/src/renderer/components/DatabaseExplorer/index.ts
+++ b/src/renderer/components/DatabaseExplorer/index.ts
@@ -1,0 +1,1 @@
+export { DatabaseExplorer } from './DatabaseExplorer'

--- a/src/renderer/components/Layout/MainPanel.tsx
+++ b/src/renderer/components/Layout/MainPanel.tsx
@@ -1,5 +1,5 @@
 import { Box, Flex, Text } from '@radix-ui/themes'
-import { QueryEditor } from '../QueryEditor/QueryEditor'
+import { ActiveConnectionLayout } from '../ActiveConnectionLayout'
 import './MainPanel.css'
 
 interface MainPanelProps {
@@ -24,7 +24,7 @@ export function MainPanel({ activeConnection }: MainPanelProps) {
 
   return (
     <Box className="main-panel">
-      <QueryEditor 
+      <ActiveConnectionLayout 
         connectionId={activeConnection.id}
         connectionName={activeConnection.name}
       />

--- a/src/renderer/components/QueryWorkspace/QueryWorkspace.css
+++ b/src/renderer/components/QueryWorkspace/QueryWorkspace.css
@@ -1,0 +1,61 @@
+.query-workspace {
+  height: 100%;
+  width: 100%;
+  overflow: hidden;
+}
+
+.workspace-panels {
+  height: 100%;
+}
+
+.editor-panel {
+  overflow: hidden;
+  background: var(--gray-1);
+}
+
+.results-panel {
+  background: var(--gray-2);
+  border-top: 1px solid var(--gray-4);
+  overflow: hidden;
+}
+
+.result-table-container {
+  overflow: auto;
+  max-height: calc(100vh - 300px);
+}
+
+.error-message {
+  padding: 16px;
+  background: var(--red-2);
+  border: 1px solid var(--red-5);
+  border-radius: var(--radius-2);
+}
+
+.resize-handle-horizontal {
+  height: 5px;
+  background: var(--gray-4);
+  cursor: row-resize;
+  position: relative;
+  transition: background-color 0.2s;
+}
+
+.resize-handle-horizontal:hover {
+  background: var(--gray-6);
+}
+
+.resize-handle-horizontal:active {
+  background: var(--accent-9);
+}
+
+/* Add a visual indicator on the horizontal resize handle */
+.resize-handle-horizontal::after {
+  content: '';
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  height: 1px;
+  width: 20px;
+  background: var(--gray-6);
+  opacity: 0.5;
+}

--- a/src/renderer/components/QueryWorkspace/QueryWorkspace.tsx
+++ b/src/renderer/components/QueryWorkspace/QueryWorkspace.tsx
@@ -1,0 +1,176 @@
+import { useState } from 'react'
+import { Panel, PanelGroup, PanelResizeHandle } from 'react-resizable-panels'
+import { Box, Button, Flex, Text, TextArea, Card, Table } from '@radix-ui/themes'
+import './QueryWorkspace.css'
+
+interface QueryWorkspaceProps {
+  connectionId: string
+  connectionName: string
+}
+
+interface QueryResult {
+  success: boolean
+  data?: any[]
+  message: string
+  error?: string
+}
+
+export function QueryWorkspace({ connectionId, connectionName }: QueryWorkspaceProps) {
+  const [query, setQuery] = useState('SELECT * FROM dummy_db.users')
+  const [result, setResult] = useState<QueryResult | null>(null)
+  const [isExecuting, setIsExecuting] = useState(false)
+
+  const handleExecuteQuery = async () => {
+    if (!query.trim()) return
+
+    try {
+      setIsExecuting(true)
+      setResult(null)
+      
+      const queryResult = await window.api.database.query(connectionId, query.trim())
+      console.log('Query result:', queryResult)
+      setResult(queryResult)
+    } catch (error) {
+      console.error('Query execution error:', error)
+      setResult({
+        success: false,
+        message: 'Query execution failed',
+        error: error instanceof Error ? error.message : 'Unknown error'
+      })
+    } finally {
+      setIsExecuting(false)
+    }
+  }
+
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === 'Enter' && (e.metaKey || e.ctrlKey)) {
+      e.preventDefault()
+      handleExecuteQuery()
+    }
+  }
+
+  const formatResult = (data: any[]) => {
+    if (!data || data.length === 0) {
+      return <Text color="gray">No data returned</Text>
+    }
+
+    let rows = data
+    let columns: string[] = []
+
+    if (Array.isArray(data) && data.length > 0) {
+      const firstRow = data[0]
+      if (typeof firstRow === 'object' && firstRow !== null) {
+        columns = Object.keys(firstRow)
+      } else {
+        columns = ['value']
+        rows = data.map(value => ({ value }))
+      }
+    }
+    
+    return (
+      <Table.Root>
+        <Table.Header>
+          <Table.Row>
+            {columns.map((column) => (
+              <Table.ColumnHeaderCell key={column}>
+                {column}
+              </Table.ColumnHeaderCell>
+            ))}
+          </Table.Row>
+        </Table.Header>
+        <Table.Body>
+          {rows.map((row, index) => (
+            <Table.Row key={index}>
+              {columns.map((column) => (
+                <Table.Cell key={column}>
+                  {row[column] !== null && row[column] !== undefined 
+                    ? String(row[column]) 
+                    : <Text color="gray">null</Text>
+                  }
+                </Table.Cell>
+              ))}
+            </Table.Row>
+          ))}
+        </Table.Body>
+      </Table.Root>
+    )
+  }
+
+  return (
+    <Box className="query-workspace">
+      <PanelGroup direction="vertical" className="workspace-panels">
+        {/* Top panel: Query editor */}
+        <Panel defaultSize={40} minSize={20} className="editor-panel">
+          <Flex direction="column" height="100%" p="3">
+            <Flex justify="between" align="center" mb="3">
+              <Text size="3" weight="bold">Query Editor</Text>
+              <Text size="1" color="gray">Cmd/Ctrl + Enter to execute</Text>
+            </Flex>
+            
+            <Box style={{ flex: 1, display: 'flex', flexDirection: 'column' }}>
+              <TextArea
+                value={query}
+                onChange={(e) => setQuery(e.target.value)}
+                onKeyDown={handleKeyDown}
+                placeholder="Enter your SQL query here..."
+                style={{ 
+                  flex: 1, 
+                  width: '100%', 
+                  resize: 'none',
+                  fontFamily: 'monospace',
+                  fontSize: '14px'
+                }}
+              />
+              <Flex justify="end" mt="2" gap="2">
+                <Button 
+                  onClick={handleExecuteQuery} 
+                  disabled={isExecuting || !query.trim()}
+                  variant="solid"
+                >
+                  {isExecuting ? 'Executing...' : 'Execute Query'}
+                </Button>
+              </Flex>
+            </Box>
+          </Flex>
+        </Panel>
+        
+        <PanelResizeHandle className="resize-handle-horizontal" />
+        
+        {/* Bottom panel: Results */}
+        <Panel defaultSize={60} minSize={20} className="results-panel">
+          <Box p="3" style={{ height: '100%', overflow: 'auto' }}>
+            <Text size="3" weight="bold" mb="3">Results</Text>
+            
+            {result ? (
+              result.success ? (
+                <Box>
+                  <Text size="1" color="gray" mb="2">
+                    {result.message}
+                  </Text>
+                  <Box className="result-table-container">
+                    {formatResult(result.data || [])}
+                  </Box>
+                </Box>
+              ) : (
+                <Box className="error-message">
+                  <Text color="red" weight="bold">
+                    Error: {result.message}
+                  </Text>
+                  {result.error && (
+                    <Text size="1" color="red" mt="1" style={{ display: 'block' }}>
+                      {result.error}
+                    </Text>
+                  )}
+                </Box>
+              )
+            ) : (
+              <Text color="gray" size="2">
+                Execute a query to see results here
+              </Text>
+            )}
+          </Box>
+        </Panel>
+      </PanelGroup>
+    </Box>
+  )
+}

--- a/src/renderer/components/QueryWorkspace/index.ts
+++ b/src/renderer/components/QueryWorkspace/index.ts
@@ -1,0 +1,1 @@
+export { QueryWorkspace } from './QueryWorkspace'

--- a/src/renderer/index.css
+++ b/src/renderer/index.css
@@ -14,5 +14,6 @@ body {
 
 #root {
   height: 100vh;
+  width: 100vw;
   overflow: hidden;
 }


### PR DESCRIPTION
- Add react-resizable-panels for split pane functionality
- Create ActiveConnectionLayout component that shows when connected
- Add DatabaseExplorer sidebar for future database tree view
- Refactor QueryWorkspace with resizable query editor and results panes
- Remove container width restrictions for full screen usage
- Add disconnect functionality with header bar
- Query editor now takes full width of its panel
- Results properly displayed in separate resizable panel