### PR TITLE
Add platform-specific styling support: Refine Connect form layout for Electron

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,7 +2,7 @@
   "editor.formatOnSave": true,
   "editor.defaultFormatter": "esbenp.prettier-vscode",
   "editor.codeActionsOnSave": {
-    "source.fixAll.eslint": true
+    "source.fixAll.eslint": "explicit"
   },
   "eslint.validate": [
     "javascript",

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,7 +2,7 @@
   "editor.formatOnSave": true,
   "editor.defaultFormatter": "esbenp.prettier-vscode",
   "editor.codeActionsOnSave": {
-    "source.fixAll.eslint": "true"
+    "source.fixAll.eslint": true
   },
   "eslint.validate": [
     "javascript",

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,7 +2,7 @@
   "editor.formatOnSave": true,
   "editor.defaultFormatter": "esbenp.prettier-vscode",
   "editor.codeActionsOnSave": {
-    "source.fixAll.eslint": "explicit"
+    "source.fixAll.eslint": "true"
   },
   "eslint.validate": [
     "javascript",

--- a/src/renderer/components/DatabaseConnection/DatabaseConnection.css
+++ b/src/renderer/components/DatabaseConnection/DatabaseConnection.css
@@ -1,3 +1,15 @@
 .full-width {
   width: 100%;
 }
+
+.card-web {
+  padding: 24px;
+  margin-top: -40px;
+  transform-origin: center;
+}
+
+.card-electron {
+  margin-top: -60px;
+  transform: scale(0.9);
+  transform-origin: center;
+}

--- a/src/renderer/components/DatabaseConnection/DatabaseConnection.tsx
+++ b/src/renderer/components/DatabaseConnection/DatabaseConnection.tsx
@@ -3,6 +3,8 @@ import { Button, Input, Label, Dialog, Flex, Select, Text, Card } from '../ui'
 import { TextField, Checkbox } from '@radix-ui/themes'
 import './DatabaseConnection.css'
 
+const isElectron = typeof window !== 'undefined' && window.process?.type === 'renderer'
+
 interface DatabaseConnectionProps {
   onConnectionSuccess?: (connection: any) => void
   onCancel?: () => void
@@ -211,10 +213,14 @@ export function DatabaseConnection({
     }
   }
 
+  const isElectron = () => {
+    return navigator.userAgent.toLowerCase().includes('electron')
+  }
+
   // Inline form mode
   if (inline) {
     return (
-      <Card style={{ padding: '24px' }}>
+      <Card className={isElectron() ? 'card-electron' : 'card-web'}>
         <Flex direction="column" gap="4">
           <Text size="4" weight="medium">
             Connect to Database

--- a/src/renderer/components/DatabaseConnection/DatabaseConnection.tsx
+++ b/src/renderer/components/DatabaseConnection/DatabaseConnection.tsx
@@ -3,8 +3,6 @@ import { Button, Input, Label, Dialog, Flex, Select, Text, Card } from '../ui'
 import { TextField, Checkbox } from '@radix-ui/themes'
 import './DatabaseConnection.css'
 
-const isElectron = typeof window !== 'undefined' && window.process?.type === 'renderer'
-
 interface DatabaseConnectionProps {
   onConnectionSuccess?: (connection: any) => void
   onCancel?: () => void


### PR DESCRIPTION
This PR enhances the visual layout specifically for the Electron build of DataPup by applying platform-aware CSS classes. It introduces conditional styling via isElectron() and styles defined in DatabaseConnection.css, resulting in a tighter, more proportional UI for Electron without affecting the web layout.

**#Type of Change**
-  UI/UX improvement
-  Code refactoring

**# Related Issues**
Part of improving platform-specific UX. No issue currently tracked.

**#Testing**

-  I have tested these changes locally in both web and Electron
-  I have tested on a large screen and small screen
-  The layout is responsive and adjusts correctly

Observe layout of connect form

Confirm styling changes based on platform

**#Additional Notes**
This prepares the foundation for future platform-specific UX differences (e.g., scaling, spacing) with clean separation in CSS.

**#Checklist**
 My code follows the project's style guidelines

 I have performed a self-review of my own code

 I have made corresponding changes to the documentation (if needed)

 My changes generate no new warnings

