### PR TITLE
Allow filter to apply on Enter key press in table view

### DIFF
--- a/src/renderer/components/TableView/TableView.tsx
+++ b/src/renderer/components/TableView/TableView.tsx
@@ -822,6 +822,11 @@ export function TableView({ connectionId, database, tableName, onFiltersChange }
                     placeholder="Value"
                     className="filter-input"
                     size="1"
+                    onKeyDown={(e) => {
+                      if (e.key === 'Enter') {
+                        executeQuery()
+                      }
+                    }}
                   />
                 )}
 


### PR DESCRIPTION
**Description**
This PR enhances the user experience in the table filter section by allowing users to trigger the filter query by pressing the Enter key inside the filter value input. Previously, the query was only executed when the "Apply filters" button was clicked.

**Type of Change**
Please mark the relevant option(s):
Enhancement (non-breaking change which fixes an issue)

**Testing**
I have tested these changes locally

**Test Instructions**
- Open a table view in the Electron app.
- Add a filter.
- Type a value into the filter input.
- Press Enter, the query should execute without clicking the "Apply filters" button.

**Additional Notes**
This small UX enhancement streamlines filtering workflow and aligns user behavior with standard form input expectations.

**Checklist**
-  My code follows the project's style guidelines
-  I have performed a self-review of my own code
-  My changes generate no new warnings

