### PR TITLE
Limit table preview query to 100 rows instead of 1000

### DIFF
--- a/src/renderer/components/TableView/TableView.tsx
+++ b/src/renderer/components/TableView/TableView.tsx
@@ -194,7 +194,7 @@ export function TableView({ connectionId, database, tableName, onFiltersChange }
       query += ` WHERE ${whereClauses.join(' AND ')}`
     }
 
-    query += ' LIMIT 1000'
+    query += ' LIMIT 100'
     return query
   }
 


### PR DESCRIPTION
**Description**
This PR fixes an issue where clicking on a table in the sidebar would preview 1,000 rows by default. To improve performance and readability, this has been reduced to 100 rows.

**Type of Change**
 Bug fix (non-breaking change which fixes an issue)

Related Issues
Fixes #61

**Testing**
 I have tested these changes locally

**Test Instructions**
- Click on any table in the sidebar
- Confirm that the preview loads only up to 100 rows
- Confirm that filters and other interactions still work as expected

**Additional Notes**
This improves app performance for large tables by reducing the default preview dataset size.

**Checklist**
-  My code follows the project's style guidelines
-  I have performed a self-review of my own code
-  My changes generate no new warnings