### PR TITLE
refactor: move SQL query building from UI to database adapters

### DIFF
--- a/src/main/database/interface.ts
+++ b/src/main/database/interface.ts
@@ -98,6 +98,33 @@ export interface BulkOperationResult {
   data?: any[] // Updated rows after operations
 }
 
+export interface TableFilter {
+  column: string
+  operator:
+    | '='
+    | '!='
+    | '>'
+    | '<'
+    | '>='
+    | '<='
+    | 'LIKE'
+    | 'NOT LIKE'
+    | 'IN'
+    | 'NOT IN'
+    | 'IS NULL'
+    | 'IS NOT NULL'
+  value?: string | string[] | number | number[]
+}
+
+export interface TableQueryOptions {
+  database: string
+  table: string
+  filters?: TableFilter[]
+  orderBy?: Array<{ column: string; direction: 'asc' | 'desc' }>
+  limit?: number
+  offset?: number
+}
+
 export interface DatabaseManagerInterface {
   // Connection management
   connect(config: DatabaseConfig, connectionId: string): Promise<ConnectionResult>
@@ -108,6 +135,13 @@ export interface DatabaseManagerInterface {
   // Query execution
   query(connectionId: string, sql: string, sessionId?: string): Promise<QueryResult>
   cancelQuery(connectionId: string, queryId: string): Promise<{ success: boolean; message: string }>
+
+  // Table query with filters
+  queryTable(
+    connectionId: string,
+    options: TableQueryOptions,
+    sessionId?: string
+  ): Promise<QueryResult>
 
   // CRUD operations
   insertRow(

--- a/src/main/database/manager.ts
+++ b/src/main/database/manager.ts
@@ -10,7 +10,8 @@ import {
   DatabaseCapabilities,
   TransactionHandle,
   BulkOperation,
-  BulkOperationResult
+  BulkOperationResult,
+  TableQueryOptions
 } from './interface'
 import { DatabaseManagerFactory } from './factory'
 
@@ -183,6 +184,31 @@ class DatabaseManager {
       return {
         success: false,
         message: error instanceof Error ? error.message : 'Failed to cancel query'
+      }
+    }
+  }
+
+  async queryTable(
+    connectionId: string,
+    options: TableQueryOptions,
+    sessionId?: string
+  ): Promise<QueryResult> {
+    try {
+      if (!this.activeConnection || this.activeConnection.id !== connectionId) {
+        return {
+          success: false,
+          message: 'Connection not found. Please connect first.',
+          error: 'No active connection'
+        }
+      }
+
+      return await this.activeConnection.manager.queryTable(connectionId, options, sessionId)
+    } catch (error) {
+      console.error('Table query error:', error)
+      return {
+        success: false,
+        message: 'Table query execution failed',
+        error: error instanceof Error ? error.message : 'Unknown error'
       }
     }
   }

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -3,7 +3,7 @@ import { join } from 'path'
 import { electronApp, optimizer, is } from '@electron-toolkit/utils'
 import { SecureStorage, DatabaseConnection } from './secureStorage'
 import { DatabaseManager } from './database/manager'
-import { DatabaseConfig } from './database/interface'
+import { DatabaseConfig, TableQueryOptions } from './database/interface'
 import { LangChainAgent } from './llm/langchainAgent'
 import * as fs from 'fs'
 
@@ -188,6 +188,23 @@ ipcMain.handle('db:query', async (_, connectionId: string, query: string, sessio
     }
   }
 })
+
+ipcMain.handle(
+  'db:queryTable',
+  async (_, connectionId: string, options: TableQueryOptions, sessionId?: string) => {
+    try {
+      const result = await databaseManager.queryTable(connectionId, options, sessionId)
+      return result
+    } catch (error) {
+      console.error('Table query execution error:', error)
+      return {
+        success: false,
+        message: 'Table query execution failed',
+        error: error instanceof Error ? error.message : 'Unknown error'
+      }
+    }
+  }
+)
 
 ipcMain.handle('db:cancelQuery', async (_, connectionId: string, queryId: string) => {
   try {

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -9,6 +9,8 @@ const api = {
     disconnect: (connectionId?: string) => ipcRenderer.invoke('db:disconnect', connectionId),
     query: (connectionId: string, sql: string, sessionId?: string) =>
       ipcRenderer.invoke('db:query', connectionId, sql, sessionId),
+    queryTable: (connectionId: string, options: any, sessionId?: string) =>
+      ipcRenderer.invoke('db:queryTable', connectionId, options, sessionId),
     cancelQuery: (connectionId: string, queryId: string) =>
       ipcRenderer.invoke('db:cancelQuery', connectionId, queryId),
     getDatabases: (connectionId: string) => ipcRenderer.invoke('db:getDatabases', connectionId),

--- a/src/renderer/types/global.d.ts
+++ b/src/renderer/types/global.d.ts
@@ -16,6 +16,34 @@ declare global {
           sql: string,
           sessionId?: string
         ) => Promise<{ success: boolean; data?: any[]; message: string; error?: string }>
+        queryTable: (
+          connectionId: string,
+          options: {
+            database: string
+            table: string
+            filters?: Array<{
+              column: string
+              operator:
+                | '='
+                | '!='
+                | '>'
+                | '<'
+                | '>='
+                | '<='
+                | 'LIKE'
+                | 'NOT LIKE'
+                | 'IN'
+                | 'NOT IN'
+                | 'IS NULL'
+                | 'IS NOT NULL'
+              value?: string | string[] | number | number[]
+            }>
+            orderBy?: Array<{ column: string; direction: 'asc' | 'desc' }>
+            limit?: number
+            offset?: number
+          },
+          sessionId?: string
+        ) => Promise<{ success: boolean; data?: any[]; message: string; error?: string }>
         cancelQuery: (
           connectionId: string,
           queryId: string

--- a/src/renderer/types/tabs.ts
+++ b/src/renderer/types/tabs.ts
@@ -27,6 +27,7 @@ export interface TableFilter {
     | '>='
     | '<='
     | 'LIKE'
+    | 'NOT LIKE'
     | 'IN'
     | 'NOT IN'
     | 'IS NULL'


### PR DESCRIPTION
- Add queryTable method to database interface and implementations
- Move filter-to-SQL logic from TableView to database-specific adapters
- ClickHouse adapter uses backticks and proper escaping
- Base implementation provides default SQL Standard syntax
- Update IPC handlers and window API types
- Refactor TableView to use abstract filter options instead of SQL

This makes the codebase more scalable for adding new database types as each adapter can implement its own SQL dialect and query building logic.
