### PR TITLE
Aligns elements properly in  connection card layout

### DIFF
--- a/package.json
+++ b/package.json
@@ -103,6 +103,7 @@
     "better-sqlite3": "^12.2.0",
     "framer-motion": "^12.23.0",
     "langchain": "^0.3.30",
+    "lucide-react": "^0.536.0",
     "monaco-editor": "^0.52.2",
     "pg": "^8.13.1",
     "react": "^19.1.0",

--- a/src/renderer/components/ConnectionCard/ConnectionCard.css
+++ b/src/renderer/components/ConnectionCard/ConnectionCard.css
@@ -3,7 +3,7 @@
   display: flex;
   flex-direction: column;
   position: relative;
-  width: 240px;
+  width: 260px;
   cursor: pointer;
   transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
   transform: translateY(0);

--- a/src/renderer/components/ConnectionCard/ConnectionCard.css
+++ b/src/renderer/components/ConnectionCard/ConnectionCard.css
@@ -3,7 +3,7 @@
   display: flex;
   flex-direction: column;
   position: relative;
-  width: 260px;
+  width: 270px;
   cursor: pointer;
   transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
   transform: translateY(0);

--- a/src/renderer/components/ConnectionCard/ConnectionCard.tsx
+++ b/src/renderer/components/ConnectionCard/ConnectionCard.tsx
@@ -2,6 +2,7 @@ import { Card, Flex, Text, Button, Box } from '../ui'
 import { DropdownMenu, Badge, Spinner } from '@radix-ui/themes'
 import { DotsVerticalIcon } from '@radix-ui/react-icons'
 import { useState } from 'react'
+import { LockKeyhole } from 'lucide-react'
 import './ConnectionCard.css'
 
 interface ConnectionCardProps {
@@ -182,11 +183,6 @@ export function ConnectionCard({
                     {connection.database}
                   </Text>
                 </Flex>
-                {connection.readonly && (
-                  <Badge size="1" color="amber" variant="soft">
-                    Read-only
-                  </Badge>
-                )}
               </Flex>
             </Box>
 
@@ -194,10 +190,18 @@ export function ConnectionCard({
               <Text size="1" color="gray">
                 @{connection.username}
               </Text>
+              {connection.readonly && (
+                <Badge size="1" color="amber" variant="soft">
+                  Read-only
+                </Badge>
+              )}
               {connection.secure && (
-                <Text size="1" color="green" weight="medium">
-                  🔒 Secure
-                </Text>
+                <Flex align="center" gap="1">
+                  <LockKeyhole size={14} color="green" />
+                  <Text size="1" color="green" weight="medium">
+                    Secure
+                  </Text>
+                </Flex>
               )}
               <Text size="1" color="gray">
                 {formatLastUsed(connection.lastUsed || connection.createdAt)}

--- a/src/renderer/components/ConnectionCard/ConnectionCard.tsx
+++ b/src/renderer/components/ConnectionCard/ConnectionCard.tsx
@@ -171,20 +171,17 @@ export function ConnectionCard({
               <Flex align="center" gap="2">
                 <Flex direction="column" gap="1">
                   <Text size="1" color="gray">
-                    host: {connection.host}
+                    <strong>host: </strong> {connection.host}
                   </Text>
                   <Text size="1" color="gray">
-                    port: {connection.port}
+                    <strong>port: </strong>
+                    {connection.port}
                   </Text>
                   <Text size="1" color="gray">
-                    db: {connection.database}
+                    <strong>db: </strong>
+                    {connection.database}
                   </Text>
                 </Flex>
-                {connection.secure && (
-                  <Text size="1" color="green" weight="medium">
-                    🔒 Secure
-                  </Text>
-                )}
                 {connection.readonly && (
                   <Badge size="1" color="amber" variant="soft">
                     Read-only
@@ -197,6 +194,11 @@ export function ConnectionCard({
               <Text size="1" color="gray">
                 @{connection.username}
               </Text>
+              {connection.secure && (
+                <Text size="1" color="green" weight="medium">
+                  🔒 Secure
+                </Text>
+              )}
               <Text size="1" color="gray">
                 {formatLastUsed(connection.lastUsed || connection.createdAt)}
               </Text>

--- a/src/renderer/components/ConnectionCard/ConnectionCard.tsx
+++ b/src/renderer/components/ConnectionCard/ConnectionCard.tsx
@@ -93,7 +93,11 @@ export function ConnectionCard({
     >
       <Box className="card-glow" />
 
-      <Flex direction="column" gap="2" className={`card-content ${isLoadingConnection ? 'loading' : ''}`}>
+      <Flex
+        direction="column"
+        gap="2"
+        className={`card-content ${isLoadingConnection ? 'loading' : ''}`}
+      >
         {isLoadingConnection ? (
           <Flex className="card-loading">
             <Spinner className="custom-spinner" />
@@ -165,9 +169,17 @@ export function ConnectionCard({
 
             <Box className="connection-details">
               <Flex align="center" gap="2">
-                <Text size="1" color="gray">
-                  {connection.host}:{connection.port}/{connection.database}
-                </Text>
+                <Flex direction="column" gap="1">
+                  <Text size="1" color="gray">
+                    host: {connection.host}
+                  </Text>
+                  <Text size="1" color="gray">
+                    port: {connection.port}
+                  </Text>
+                  <Text size="1" color="gray">
+                    db: {connection.database}
+                  </Text>
+                </Flex>
                 {connection.secure && (
                   <Text size="1" color="green" weight="medium">
                     🔒 Secure


### PR DESCRIPTION
## Description

The PR aligns the host, port and db consistently in the Connections card.

## Type of Change

Please mark the relevant option(s):

-  🐛 Bug fix (non-breaking change which fixes an issue)

Fixes #

## Screenshots/Recordings

### Before

<img width="397" height="205" alt="470069164-8390111a-f8fa-419c-9e49-d50f9c8f37ec" src="https://github.com/user-attachments/assets/fbccd511-90ea-4373-811a-d4b521a2be81" />


### After
<img width="399" height="256" alt="Screenshot 2025-08-04 at 12 24 15 PM" src="https://github.com/user-attachments/assets/546ee2de-7c47-4b41-81c4-ad2493a690d5" />


## Testing

Please confirm the following:

- [x] I have tested these changes locally
- [x] I have tested on different screen sizes (if UI changes)


### Test Instructions

<!-- Provide step-by-step instructions for testing your changes -->

1. Launch the DataPup app
2. Create or view an existing connection card
3. Observe the layout of the connection details



## Checklist

-  My code follows the project's style guidelines
-  I have performed a self-review of my own code
-  My changes generate no new warnings
-  Any dependent changes have been merged and published

