### PR TITLE
fix:preserve ai chat history when switching views

### DIFF
--- a/package.json
+++ b/package.json
@@ -103,6 +103,7 @@
     "better-sqlite3": "^12.2.0",
     "framer-motion": "^12.23.0",
     "langchain": "^0.3.30",
+    "lucide-react": "^0.536.0",
     "monaco-editor": "^0.52.2",
     "pg": "^8.13.1",
     "react": "^19.1.0",

--- a/src/renderer/components/AIAssistant/AIAssistant.tsx
+++ b/src/renderer/components/AIAssistant/AIAssistant.tsx
@@ -1,5 +1,6 @@
 import { useState, useRef, useEffect } from 'react'
 import { Box, Flex, Text, Button, ScrollArea, TextArea, Card, Select } from '@radix-ui/themes'
+import { TrashIcon } from '@radix-ui/react-icons'
 import { MessageRenderer } from './MessageRenderer'
 import { useChatContext, type AIContext } from '../../contexts/ChatContext'
 import './AIAssistant.css'
@@ -21,7 +22,7 @@ export function AIAssistant({ context, onExecuteQuery, onClose }: AIAssistantPro
     setProvider,
     clearChat
   } = useChatContext()
-  
+
   const [inputValue, setInputValue] = useState('')
   const [apiKeyInput, setApiKeyInput] = useState('')
   const scrollAreaRef = useRef<HTMLDivElement>(null)
@@ -40,7 +41,7 @@ export function AIAssistant({ context, onExecuteQuery, onClose }: AIAssistantPro
 
     const userInput = inputValue.trim()
     setInputValue('')
-    
+
     await sendMessage(userInput, context, onExecuteQuery)
   }
 
@@ -170,13 +171,13 @@ export function AIAssistant({ context, onExecuteQuery, onClose }: AIAssistantPro
             </Select.Content>
           </Select.Root>
           {messages.length > 0 && (
-            <Button 
-              size="1" 
-              variant="ghost" 
+            <Button
+              size="1"
+              variant="ghost"
               onClick={clearChat}
               title="Clear chat history"
             >
-              🗑️
+              Clear Chat<TrashIcon />
             </Button>
           )}
           {onClose && (

--- a/src/renderer/components/AIAssistant/AIAssistant.tsx
+++ b/src/renderer/components/AIAssistant/AIAssistant.tsx
@@ -1,6 +1,6 @@
 import { useState, useRef, useEffect } from 'react'
 import { Box, Flex, Text, Button, ScrollArea, TextArea, Card, Select } from '@radix-ui/themes'
-import { TrashIcon } from '@radix-ui/react-icons'
+import { Trash2 } from 'lucide-react'
 import { MessageRenderer } from './MessageRenderer'
 import { useChatContext, type AIContext } from '../../contexts/ChatContext'
 import './AIAssistant.css'
@@ -177,7 +177,7 @@ export function AIAssistant({ context, onExecuteQuery, onClose }: AIAssistantPro
               onClick={clearChat}
               title="Clear chat history"
             >
-              Clear Chat<TrashIcon />
+              <Trash2 size={16} />
             </Button>
           )}
           {onClose && (

--- a/src/renderer/components/AIAssistant/AIAssistant.tsx
+++ b/src/renderer/components/AIAssistant/AIAssistant.tsx
@@ -1,24 +1,8 @@
 import { useState, useRef, useEffect } from 'react'
 import { Box, Flex, Text, Button, ScrollArea, TextArea, Card, Select } from '@radix-ui/themes'
 import { MessageRenderer } from './MessageRenderer'
+import { useChatContext, type AIContext } from '../../contexts/ChatContext'
 import './AIAssistant.css'
-
-interface Message {
-  id: string
-  role: 'user' | 'assistant' | 'tool'
-  content: string
-  timestamp: Date
-  sqlQuery?: string
-  toolCall?: {
-    name: string
-    status: 'running' | 'completed' | 'failed'
-  }
-}
-
-interface AIContext {
-  connectionId?: string
-  database?: string
-}
 
 interface AIAssistantProps {
   context: AIContext
@@ -27,90 +11,22 @@ interface AIAssistantProps {
 }
 
 export function AIAssistant({ context, onExecuteQuery, onClose }: AIAssistantProps) {
-  const [messages, setMessages] = useState<Message[]>([])
+  const {
+    messages,
+    isLoading,
+    provider,
+    showApiKeySetup,
+    sendMessage,
+    handleApiKeySubmit,
+    setProvider,
+    clearChat
+  } = useChatContext()
+  
   const [inputValue, setInputValue] = useState('')
-  const [isLoading, setIsLoading] = useState(false)
-  const [provider, setProvider] = useState<'openai' | 'claude' | 'gemini'>(() => {
-    const saved = localStorage.getItem('datapup-ai-provider')
-    if (saved && ['openai', 'claude', 'gemini'].includes(saved)) {
-      return saved as 'openai' | 'claude' | 'gemini'
-    }
-    return 'openai'
-  })
-  const [apiKey, setApiKey] = useState<string | null>(null)
-  const [showApiKeySetup, setShowApiKeySetup] = useState(false)
   const [apiKeyInput, setApiKeyInput] = useState('')
   const scrollAreaRef = useRef<HTMLDivElement>(null)
   const inputRef = useRef<HTMLTextAreaElement>(null)
 
-  // Generate session ID that persists for the lifetime of this component
-  const sessionIdRef = useRef(`session-${Date.now()}-${Math.random().toString(36).substr(2, 9)}`)
-  const sessionId = sessionIdRef.current
-
-  // Check for API key on mount and when provider changes
-  useEffect(() => {
-    const checkApiKey = async () => {
-      try {
-        const result = await window.api.secureStorage.get(`ai-api-key-${provider}`)
-        if (result.success && result.value) {
-          setApiKey(result.value)
-          setShowApiKeySetup(false)
-        } else {
-          setShowApiKeySetup(true)
-        }
-      } catch (error) {
-        console.error('[AIAssistant] Error checking API key:', error)
-        setShowApiKeySetup(true)
-      }
-    }
-    checkApiKey()
-  }, [provider])
-
-  // Listen for tool call events from backend
-  useEffect(() => {
-    const handleToolCall = (event: any, data: any) => {
-      const toolMessage: Message = {
-        id: `tool-${Date.now()}-${Math.random()}`,
-        role: 'tool',
-        content: '',
-        timestamp: new Date(),
-        toolCall: {
-          name: data.name,
-          status: data.status
-        }
-      }
-
-      setMessages((prev) => {
-        // Update existing tool message or add new one
-        const existingIndex = prev.findIndex(
-          (msg) =>
-            msg.role === 'tool' &&
-            msg.toolCall?.name === data.name &&
-            msg.toolCall?.status === 'running'
-        )
-
-        if (existingIndex >= 0 && data.status === 'completed') {
-          // Update existing message
-          const updated = [...prev]
-          updated[existingIndex] = {
-            ...updated[existingIndex],
-            toolCall: { ...updated[existingIndex].toolCall!, status: 'completed' }
-          }
-          return updated
-        } else {
-          // Add new message
-          return [...prev, toolMessage]
-        }
-      })
-    }
-
-    // Subscribe to tool call events
-    const removeListener = window.api.on('ai:toolCall', handleToolCall)
-
-    return () => {
-      removeListener()
-    }
-  }, [])
 
   // Auto-scroll to bottom when new messages arrive
   useEffect(() => {
@@ -124,56 +40,8 @@ export function AIAssistant({ context, onExecuteQuery, onClose }: AIAssistantPro
 
     const userInput = inputValue.trim()
     setInputValue('')
-    setIsLoading(true)
-
-    const userMessage: Message = {
-      id: Date.now().toString(),
-      role: 'user',
-      content: userInput,
-      timestamp: new Date()
-    }
-
-    setMessages((prev) => [...prev, userMessage])
-
-    try {
-      // Use single AI process method with session ID
-      const result = await window.api.ai.process({
-        query: userInput,
-        connectionId: context.connectionId || '',
-        database: context.database || undefined,
-        provider: provider,
-        sessionId: sessionId
-      })
-
-      if (result.success) {
-        const assistantMessage: Message = {
-          id: (Date.now() + 1).toString(),
-          role: 'assistant',
-          content: result.message || result.explanation || 'No response generated.',
-          timestamp: new Date(),
-          sqlQuery: result.sqlQuery
-        }
-        setMessages((prev) => [...prev, assistantMessage])
-      } else {
-        const errorMessage: Message = {
-          id: (Date.now() + 1).toString(),
-          role: 'assistant',
-          content: `Error: ${result.error || 'Unknown error occurred'}`,
-          timestamp: new Date()
-        }
-        setMessages((prev) => [...prev, errorMessage])
-      }
-    } catch (error) {
-      const errorMessage: Message = {
-        id: (Date.now() + 1).toString(),
-        role: 'assistant',
-        content: `Error: ${error instanceof Error ? error.message : 'Unknown error occurred'}`,
-        timestamp: new Date()
-      }
-      setMessages((prev) => [...prev, errorMessage])
-    } finally {
-      setIsLoading(false)
-    }
+    
+    await sendMessage(userInput, context, onExecuteQuery)
   }
 
   const handleKeyDown = (e: React.KeyboardEvent) => {
@@ -183,23 +51,14 @@ export function AIAssistant({ context, onExecuteQuery, onClose }: AIAssistantPro
     }
   }
 
-  const handleApiKeySubmit = async (key: string) => {
-    try {
-      const result = await window.api.secureStorage.set(`ai-api-key-${provider}`, key)
-      if (result.success) {
-        setApiKey(key)
-        setShowApiKeySetup(false)
-        setApiKeyInput('')
-      }
-    } catch (error) {
-      console.error('[AIAssistant] Error saving API key:', error)
-    }
+  const handleApiKeySubmitLocal = async (key: string) => {
+    await handleApiKeySubmit(key, provider)
+    setApiKeyInput('')
   }
 
   const handleProviderChange = (newProvider: string) => {
     if (['openai', 'claude', 'gemini'].includes(newProvider)) {
       setProvider(newProvider as 'openai' | 'claude' | 'gemini')
-      localStorage.setItem('datapup-ai-provider', newProvider)
     }
   }
 
@@ -273,7 +132,7 @@ export function AIAssistant({ context, onExecuteQuery, onClose }: AIAssistantPro
                   onKeyDown={(e) => {
                     if (e.key === 'Enter' && !e.shiftKey) {
                       e.preventDefault()
-                      if (apiKeyInput.trim()) handleApiKeySubmit(apiKeyInput.trim())
+                      if (apiKeyInput.trim()) handleApiKeySubmitLocal(apiKeyInput.trim())
                     }
                   }}
                 />
@@ -282,7 +141,7 @@ export function AIAssistant({ context, onExecuteQuery, onClose }: AIAssistantPro
               <Button
                 size="2"
                 onClick={() => {
-                  if (apiKeyInput.trim()) handleApiKeySubmit(apiKeyInput.trim())
+                  if (apiKeyInput.trim()) handleApiKeySubmitLocal(apiKeyInput.trim())
                 }}
                 disabled={!apiKeyInput.trim()}
               >
@@ -310,6 +169,16 @@ export function AIAssistant({ context, onExecuteQuery, onClose }: AIAssistantPro
               <Select.Item value="gemini">Gemini</Select.Item>
             </Select.Content>
           </Select.Root>
+          {messages.length > 0 && (
+            <Button 
+              size="1" 
+              variant="ghost" 
+              onClick={clearChat}
+              title="Clear chat history"
+            >
+              🗑️
+            </Button>
+          )}
           {onClose && (
             <Button size="1" variant="ghost" onClick={onClose}>
               ×

--- a/src/renderer/components/ActiveConnectionLayout/ActiveConnectionLayout.tsx
+++ b/src/renderer/components/ActiveConnectionLayout/ActiveConnectionLayout.tsx
@@ -4,6 +4,7 @@ import { Button } from '../ui'
 import { LeftSidebar } from '../LeftSidebar'
 import { QueryWorkspace } from '../QueryWorkspace/QueryWorkspace'
 import { ThemeSwitcher } from '../ThemeSwitcher'
+import { ChatProvider } from '../../contexts/ChatContext'
 import { useState, useEffect, useRef } from 'react'
 import './ActiveConnectionLayout.css'
 
@@ -76,55 +77,57 @@ export function ActiveConnectionLayout({
   }
 
   return (
-    <Box className="active-connection-layout">
-      {/* Header bar */}
-      <Flex className="connection-header" justify="between" align="center" p="2">
-        <Flex align="center" gap="2">
-          <Text size="2" weight="medium">
-            {connectionName}
-          </Text>
-          {isReadOnly && (
-            <Badge size="1" color="amber" variant="soft">
-              READ-ONLY
-            </Badge>
-          )}
+    <ChatProvider connectionId={connectionId}>
+      <Box className="active-connection-layout">
+        {/* Header bar */}
+        <Flex className="connection-header" justify="between" align="center" p="2">
+          <Flex align="center" gap="2">
+            <Text size="2" weight="medium">
+              {connectionName}
+            </Text>
+            {isReadOnly && (
+              <Badge size="1" color="amber" variant="soft">
+                READ-ONLY
+              </Badge>
+            )}
+          </Flex>
+          <Flex align="center" gap="2">
+            <ThemeSwitcher size="1" />
+            <Button size="1" variant="soft" color="red" onClick={onDisconnect}>
+              Disconnect
+            </Button>
+          </Flex>
         </Flex>
-        <Flex align="center" gap="2">
-          <ThemeSwitcher size="1" />
-          <Button size="1" variant="soft" color="red" onClick={onDisconnect}>
-            Disconnect
-          </Button>
-        </Flex>
-      </Flex>
 
-      <PanelGroup direction="horizontal" className="panel-group">
-        {/* Left sidebar with navigation */}
-        <Panel defaultSize={20} minSize={15} maxSize={40} className="explorer-panel">
-          <LeftSidebar
-            connectionId={connectionId}
-            connectionName={connectionName}
-            onTableDoubleClick={handleOpenTableTab}
-            onSelectQuery={handleSelectQuery}
-            onRunQuery={handleRunQuery}
-            onExecuteQueryFromAI={handleExecuteQueryFromAI}
-          />
-        </Panel>
+        <PanelGroup direction="horizontal" className="panel-group">
+          {/* Left sidebar with navigation */}
+          <Panel defaultSize={20} minSize={15} maxSize={40} className="explorer-panel">
+            <LeftSidebar
+              connectionId={connectionId}
+              connectionName={connectionName}
+              onTableDoubleClick={handleOpenTableTab}
+              onSelectQuery={handleSelectQuery}
+              onRunQuery={handleRunQuery}
+              onExecuteQueryFromAI={handleExecuteQueryFromAI}
+            />
+          </Panel>
 
-        <PanelResizeHandle className="resize-handle" />
+          <PanelResizeHandle className="resize-handle" />
 
-        {/* Right side with query workspace */}
-        <Panel defaultSize={80} className="workspace-panel">
-          <QueryWorkspace
-            ref={queryWorkspaceRef}
-            connectionId={connectionId}
-            connectionName={connectionName}
-            onOpenTableTab={handleOpenTableTab}
-            onRegisterNewTabHandler={(handler) => {
-              newTabHandlerRef.current = handler
-            }}
-          />
-        </Panel>
-      </PanelGroup>
-    </Box>
+          {/* Right side with query workspace */}
+          <Panel defaultSize={80} className="workspace-panel">
+            <QueryWorkspace
+              ref={queryWorkspaceRef}
+              connectionId={connectionId}
+              connectionName={connectionName}
+              onOpenTableTab={handleOpenTableTab}
+              onRegisterNewTabHandler={(handler) => {
+                newTabHandlerRef.current = handler
+              }}
+            />
+          </Panel>
+        </PanelGroup>
+      </Box>
+    </ChatProvider>
   )
 }

--- a/src/renderer/contexts/ChatContext.tsx
+++ b/src/renderer/contexts/ChatContext.tsx
@@ -1,0 +1,260 @@
+import React, { createContext, useContext, useState, useRef, useEffect } from 'react'
+
+export interface Message {
+  id: string
+  role: 'user' | 'assistant' | 'tool'
+  content: string
+  timestamp: Date
+  sqlQuery?: string
+  toolCall?: {
+    name: string
+    status: 'running' | 'completed' | 'failed'
+  }
+}
+
+export interface AIContext {
+  connectionId?: string
+  database?: string
+}
+
+export type AIProvider = 'openai' | 'claude' | 'gemini'
+
+interface ChatContextType {
+  // State
+  messages: Message[]
+  isLoading: boolean
+  provider: AIProvider
+  apiKey: string | null
+  showApiKeySetup: boolean
+  sessionId: string
+  
+  // Actions
+  addMessage: (message: Message) => void
+  setMessages: (messages: Message[] | ((prev: Message[]) => Message[])) => void
+  setIsLoading: (loading: boolean) => void
+  setProvider: (provider: AIProvider) => void
+  setApiKey: (key: string | null) => void
+  setShowApiKeySetup: (show: boolean) => void
+  clearChat: () => void
+  
+  // AI Operations
+  sendMessage: (content: string, context: AIContext, onExecuteQuery?: (query: string) => void) => Promise<void>
+  handleApiKeySubmit: (key: string, provider: AIProvider) => Promise<void>
+}
+
+const ChatContext = createContext<ChatContextType | undefined>(undefined)
+
+export function useChatContext() {
+  const context = useContext(ChatContext)
+  if (context === undefined) {
+    throw new Error('useChatContext must be used within a ChatProvider')
+  }
+  return context
+}
+
+interface ChatProviderProps {
+  children: React.ReactNode
+  connectionId: string
+}
+
+export function ChatProvider({ children, connectionId }: ChatProviderProps) {
+  const [messages, setMessages] = useState<Message[]>([])
+  const [isLoading, setIsLoading] = useState(false)
+  const [provider, setProviderState] = useState<AIProvider>(() => {
+    const saved = localStorage.getItem('datapup-ai-provider')
+    if (saved && ['openai', 'claude', 'gemini'].includes(saved)) {
+      return saved as AIProvider
+    }
+    return 'openai'
+  })
+  const [apiKey, setApiKey] = useState<string | null>(null)
+  const [showApiKeySetup, setShowApiKeySetup] = useState(false)
+  
+  // Generate session ID that persists for the lifetime of this provider
+  const sessionIdRef = useRef(`session-${connectionId}-${Date.now()}-${Math.random().toString(36).substr(2, 9)}`)
+  const sessionId = sessionIdRef.current
+
+  // Check for API key on mount and when provider changes
+  useEffect(() => {
+    const checkApiKey = async () => {
+      try {
+        const result = await window.api.secureStorage.get(`ai-api-key-${provider}`)
+        if (result.success && result.value) {
+          setApiKey(result.value)
+          setShowApiKeySetup(false)
+        } else {
+          setShowApiKeySetup(true)
+        }
+      } catch (error) {
+        console.error('[ChatContext] Error checking API key:', error)
+        setShowApiKeySetup(true)
+      }
+    }
+    checkApiKey()
+  }, [provider])
+
+  // Listen for tool call events from backend
+  useEffect(() => {
+    const handleToolCall = (event: any, data: any) => {
+      const toolMessage: Message = {
+        id: `tool-${Date.now()}-${Math.random()}`,
+        role: 'tool',
+        content: '',
+        timestamp: new Date(),
+        toolCall: {
+          name: data.name,
+          status: data.status
+        }
+      }
+
+      setMessages((prev) => {
+        // Update existing tool message or add new one
+        const existingIndex = prev.findIndex(
+          (msg) =>
+            msg.role === 'tool' &&
+            msg.toolCall?.name === data.name &&
+            msg.toolCall?.status === 'running'
+        )
+
+        if (existingIndex >= 0 && data.status === 'completed') {
+          // Update existing message
+          const updated = [...prev]
+          updated[existingIndex] = {
+            ...updated[existingIndex],
+            toolCall: { ...updated[existingIndex].toolCall!, status: 'completed' }
+          }
+          return updated
+        } else {
+          // Add new message
+          return [...prev, toolMessage]
+        }
+      })
+    }
+
+    // Subscribe to tool call events
+    const removeListener = window.api.on('ai:toolCall', handleToolCall)
+
+    return () => {
+      removeListener()
+    }
+  }, [])
+
+  // Clear chat when connection changes
+  useEffect(() => {
+    setMessages([])
+    // Generate new session ID for new connection
+    sessionIdRef.current = `session-${connectionId}-${Date.now()}-${Math.random().toString(36).substr(2, 9)}`
+  }, [connectionId])
+
+  const addMessage = (message: Message) => {
+    setMessages(prev => [...prev, message])
+  }
+
+  const setProvider = (newProvider: AIProvider) => {
+    setProviderState(newProvider)
+    localStorage.setItem('datapup-ai-provider', newProvider)
+  }
+
+  const clearChat = () => {
+    setMessages([])
+    // Generate new session ID for fresh conversation
+    sessionIdRef.current = `session-${connectionId}-${Date.now()}-${Math.random().toString(36).substr(2, 9)}`
+  }
+
+  const sendMessage = async (content: string, context: AIContext, onExecuteQuery?: (query: string) => void) => {
+    if (!content.trim() || isLoading) return
+
+    const userInput = content.trim()
+    setIsLoading(true)
+
+    const userMessage: Message = {
+      id: Date.now().toString(),
+      role: 'user',
+      content: userInput,
+      timestamp: new Date()
+    }
+
+    addMessage(userMessage)
+
+    try {
+      // Use single AI process method with session ID
+      const result = await window.api.ai.process({
+        query: userInput,
+        connectionId: context.connectionId || '',
+        database: context.database || undefined,
+        provider: provider,
+        sessionId: sessionId
+      })
+
+      if (result.success) {
+        const assistantMessage: Message = {
+          id: (Date.now() + 1).toString(),
+          role: 'assistant',
+          content: result.message || result.explanation || 'No response generated.',
+          timestamp: new Date(),
+          sqlQuery: result.sqlQuery
+        }
+        addMessage(assistantMessage)
+      } else {
+        const errorMessage: Message = {
+          id: (Date.now() + 1).toString(),
+          role: 'assistant',
+          content: `Error: ${result.error || 'Unknown error occurred'}`,
+          timestamp: new Date()
+        }
+        addMessage(errorMessage)
+      }
+    } catch (error) {
+      const errorMessage: Message = {
+        id: (Date.now() + 1).toString(),
+        role: 'assistant',
+        content: `Error: ${error instanceof Error ? error.message : 'Unknown error occurred'}`,
+        timestamp: new Date()
+      }
+      addMessage(errorMessage)
+    } finally {
+      setIsLoading(false)
+    }
+  }
+
+  const handleApiKeySubmit = async (key: string, currentProvider: AIProvider) => {
+    try {
+      const result = await window.api.secureStorage.set(`ai-api-key-${currentProvider}`, key)
+      if (result.success) {
+        setApiKey(key)
+        setShowApiKeySetup(false)
+      }
+    } catch (error) {
+      console.error('[ChatContext] Error saving API key:', error)
+    }
+  }
+
+  const contextValue: ChatContextType = {
+    // State
+    messages,
+    isLoading,
+    provider,
+    apiKey,
+    showApiKeySetup,
+    sessionId,
+    
+    // Actions
+    addMessage,
+    setMessages,
+    setIsLoading,
+    setProvider,
+    setApiKey,
+    setShowApiKeySetup,
+    clearChat,
+    
+    // AI Operations
+    sendMessage,
+    handleApiKeySubmit
+  }
+
+  return (
+    <ChatContext.Provider value={contextValue}>
+      {children}
+    </ChatContext.Provider>
+  )
+}

--- a/src/renderer/contexts/ChatContext.tsx
+++ b/src/renderer/contexts/ChatContext.tsx
@@ -1,4 +1,5 @@
 import React, { createContext, useContext, useState, useRef, useEffect } from 'react'
+import { logger } from '../utils/logger'
 
 export interface Message {
   id: string
@@ -27,7 +28,7 @@ interface ChatContextType {
   apiKey: string | null
   showApiKeySetup: boolean
   sessionId: string
-  
+
   // Actions
   addMessage: (message: Message) => void
   setMessages: (messages: Message[] | ((prev: Message[]) => Message[])) => void
@@ -36,7 +37,7 @@ interface ChatContextType {
   setApiKey: (key: string | null) => void
   setShowApiKeySetup: (show: boolean) => void
   clearChat: () => void
-  
+
   // AI Operations
   sendMessage: (content: string, context: AIContext, onExecuteQuery?: (query: string) => void) => Promise<void>
   handleApiKeySubmit: (key: string, provider: AIProvider) => Promise<void>
@@ -69,7 +70,7 @@ export function ChatProvider({ children, connectionId }: ChatProviderProps) {
   })
   const [apiKey, setApiKey] = useState<string | null>(null)
   const [showApiKeySetup, setShowApiKeySetup] = useState(false)
-  
+
   // Generate session ID that persists for the lifetime of this provider
   const sessionIdRef = useRef(`session-${connectionId}-${Date.now()}-${Math.random().toString(36).substr(2, 9)}`)
   const sessionId = sessionIdRef.current
@@ -86,7 +87,7 @@ export function ChatProvider({ children, connectionId }: ChatProviderProps) {
           setShowApiKeySetup(true)
         }
       } catch (error) {
-        console.error('[ChatContext] Error checking API key:', error)
+        logger.error('Error checking API key:', error)
         setShowApiKeySetup(true)
       }
     }
@@ -225,7 +226,7 @@ export function ChatProvider({ children, connectionId }: ChatProviderProps) {
         setShowApiKeySetup(false)
       }
     } catch (error) {
-      console.error('[ChatContext] Error saving API key:', error)
+      logger.error('Error saving API key:', error)
     }
   }
 
@@ -237,7 +238,7 @@ export function ChatProvider({ children, connectionId }: ChatProviderProps) {
     apiKey,
     showApiKeySetup,
     sessionId,
-    
+
     // Actions
     addMessage,
     setMessages,
@@ -246,7 +247,7 @@ export function ChatProvider({ children, connectionId }: ChatProviderProps) {
     setApiKey,
     setShowApiKeySetup,
     clearChat,
-    
+
     // AI Operations
     sendMessage,
     handleApiKeySubmit

--- a/src/renderer/utils/logger.ts
+++ b/src/renderer/utils/logger.ts
@@ -1,0 +1,49 @@
+export enum LogLevel {
+  ERROR = 0,
+  WARN = 1,
+  INFO = 2,
+  DEBUG = 3
+}
+
+class RendererLogger {
+  private level: LogLevel = LogLevel.INFO
+
+  constructor() {
+    // Set log level based on environment
+    if (process.env.NODE_ENV === 'development') {
+      this.level = LogLevel.DEBUG
+    } else if (process.env.DEBUG) {
+      this.level = LogLevel.DEBUG
+    }
+  }
+
+  setLevel(level: LogLevel) {
+    this.level = level
+  }
+
+  error(message: string, ...args: any[]) {
+    if (this.level >= LogLevel.ERROR) {
+      console.error(`[ERROR] ${message}`, ...args)
+    }
+  }
+
+  warn(message: string, ...args: any[]) {
+    if (this.level >= LogLevel.WARN) {
+      console.warn(`[WARN] ${message}`, ...args)
+    }
+  }
+
+  info(message: string, ...args: any[]) {
+    if (this.level >= LogLevel.INFO) {
+      console.log(`[INFO] ${message}`, ...args)
+    }
+  }
+
+  debug(message: string, ...args: any[]) {
+    if (this.level >= LogLevel.DEBUG) {
+      console.log(`[DEBUG] ${message}`, ...args)
+    }
+  }
+}
+
+export const logger = new RendererLogger()


### PR DESCRIPTION
 **Description**
Fixes AI assistant chat history being reset when users navigate between views (AI Assistant ↔ Database Explorer). Previously, switching from the AI Assistant to Database Explorer and back would completely lose all conversation history, forcing users to restart their conversations.

This PR implements a React Context-based solution that preserves chat state at the connection level, ensuring conversations persist across view navigation while maintaining session continuity with the AI backend.

**Type of Change**
♻️ Code refactoring

**Related Issues**
Fixes # 84

**Please confirm the following:**
  - I have tested these changes locally
  - I have added/updated tests for these changes (if applicable)
  - All existing tests pass

**Test Instructions**
  1. Connect to a database and navigate to the AI Assistant view
  2. Start a conversation with the AI (ask about tables, schemas, etc.)
  3. Switch to the Database Explorer view
  4. Switch back to the AI Assistant view
  5. Verify: Chat history should be preserved and conversation can continue
  6. Bonus: Test the new clear chat button (🗑️) to manually reset conversation

**Additional Notes**
  Technical Implementation:
  - Created ChatContext.tsx for centralized AI conversation state management
  - Refactored AIAssistant.tsx to use context instead of local state
  - Wrapped ActiveConnectionLayout with ChatProvider
  - Added clear chat functionality with trash icon button
  - Session ID now persists across view changes but resets on connection changes

**Checklist**
  - My code follows the project's style guidelines
  - I have performed a self-review of my own code
  - My changes generate no new warnings