### PR TITLE
Fix Postgres Intellisense

### DIFF
--- a/package.json
+++ b/package.json
@@ -105,7 +105,7 @@
     "langchain": "^0.3.30",
     "lucide-react": "^0.536.0",
     "monaco-editor": "^0.52.2",
-    "mysql2": "^3.9.2",
+    "mysql2": "^3.14.3",
     "pg": "^8.16.3",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",

--- a/src/main/database/manager.ts
+++ b/src/main/database/manager.ts
@@ -294,7 +294,9 @@ class DatabaseManager {
   getConnectionInfo(
     connectionId: string
   ): { type: string; host: string; port: number; database: string } | null {
-    if (!this.activeConnection || this.activeConnection.id !== connectionId) return null
+    if (!this.activeConnection || this.activeConnection.id !== connectionId) {
+      return null
+    }
 
     const info = this.activeConnection.manager.getConnectionInfo(connectionId)
     return info ? { type: this.activeConnection.type, ...info } : null

--- a/src/main/database/postgresql.ts
+++ b/src/main/database/postgresql.ts
@@ -569,6 +569,22 @@ class PostgreSQLManager extends BaseDatabaseManager {
     return result as DeleteResult
   }
 
+  getConnectionInfo(
+    connectionId: string
+  ): { host: string; port: number; database: string; type: string } | null {
+    const connection = this.connections.get(connectionId)
+    if (!connection) {
+      return null
+    }
+
+    return {
+      host: connection.config.host,
+      port: connection.config.port,
+      database: connection.config.database,
+      type: 'postgresql'
+    }
+  }
+
   async cleanup(): Promise<void> {
     // Disconnect all connections
     const connectionIds = Array.from(this.connections.keys())

--- a/src/renderer/lib/intellisense/index.ts
+++ b/src/renderer/lib/intellisense/index.ts
@@ -9,7 +9,6 @@ export function createIntellisenseProvider(
   monaco: Monaco,
   options: IntellisenseOptions
 ): IntellisenseProvider {
-  console.log(`🔍 INTELLISENSE DEBUG: Creating ${options.databaseType} provider for connection ${options.connectionId}`)
   switch (options.databaseType.toLowerCase()) {
     case 'clickhouse':
       return new ClickHouseIntellisenseProvider(monaco, options)

--- a/src/renderer/lib/intellisense/index.ts
+++ b/src/renderer/lib/intellisense/index.ts
@@ -9,6 +9,7 @@ export function createIntellisenseProvider(
   monaco: Monaco,
   options: IntellisenseOptions
 ): IntellisenseProvider {
+  console.log(`🔍 INTELLISENSE DEBUG: Creating ${options.databaseType} provider for connection ${options.connectionId}`)
   switch (options.databaseType.toLowerCase()) {
     case 'clickhouse':
       return new ClickHouseIntellisenseProvider(monaco, options)


### PR DESCRIPTION
**Description**
Fixes PostgreSQL intellisense incorrectly showing table suggestions wrapped in backticks (ClickHouse format) instead of proper PostgreSQL schema.table format. The issue was caused by a race condition where intellisense was initialized with the default 'clickhouse' provider before the async database type fetch could complete and identify the connection as PostgreSQL.
**Root cause:** SqlEditor component was initializing intellisense immediately when Monaco mounted, using the default database type, while getConnectionInfo ran asynchronously in parallel.
**Solution:** Added proper initialization sequencing to ensure intellisense only initializes after both Monaco editor is ready AND the correct database type has been fetched from the backend.

**Before**
  PostgreSQL tables appeared with ClickHouse-style backticks:
  - Suggestions showed as `table_name`
  - Wrong provider was being used for PostgreSQL connections
**After**
  PostgreSQL tables now appear in proper format:
  - Suggestions show as schema.table
  - Correct PostgreSQL provider is used
  - Tables appear unquoted when selected from intellisense

**Testing**
Please confirm the following:
  - I have tested these changes locally

**Additional Notes**
  Technical changes:
  - Added monacoReady state to track when Monaco editor is fully mounted
  - Changed initial databaseType from 'clickhouse' to null to prevent premature initialization
  - Updated useEffect dependencies to require both monacoReady and databaseType
  - Removed intellisense initialization from handleEditorDidMount to prevent race condition                                                                                                 